### PR TITLE
info-bar-compose added to Libraries > UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 - [compose-richtext](https://github.com/zach-klippenstein/compose-richtext) - A collection of Compose libraries for advanced text formatting.
 - [compose-ratingbar](https://github.com/a914-gowtham/compose-ratingbar) - Ratingbar for Jetpack Compose.
 - [tehras/charts](https://github.com/tehras/charts) - simple Android compose charts.
+- [info-bar-compose](https://github.com/radusalagean/info-bar-compose) - Display Snackbar-style messages, the easy way.
 
 ### Navigation
 


### PR DESCRIPTION
An **Android Jetpack Compose library** for displaying **on-screen messages**. Unlike the built-in `Snackbar` from the Compose Material library, the `InfoBar` can be properly displayed **without additional requirements**, like `Scaffold`, `SnackbarHost` / `SnackbarHostState`, or manually starting new coroutines to show the on-screen message.